### PR TITLE
Update: add Windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "dependencies": {
     "chai": "^3.5.0",
     "js-yaml": "^3.7.0"
+  },
+  "engines": {
+    "node": ">=6"
   }
 }


### PR DESCRIPTION
On Windows, it needs `{shell: true}` option to lookup commands. The option exists since Node.js 6.

`execFileSync` does not have `shell` option, so I changed it to `spawnSync`.