### PR TITLE
Update: Disable timer custom rule in Nodejs project for now

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -38,6 +38,7 @@
     - lib
     - test
     - tools
+    - --rule=timer-arguments:off
 
 - name: redux
   repo: https://github.com/reactjs/redux


### PR DESCRIPTION
Disable nodejs since it needs node 6.0 to run. Our jenkins has node 4
Activate it in the future