### PR TITLE
Docs: Fix broken travis sticker link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# eslint-canary [![Build Status](https://travis-ci.org/eslint/eslint-canary.svg?branch=master)](https://travis-ci.org/not-an-aardvark/eslint-canary)
+# eslint-canary [![Build Status](https://travis-ci.org/eslint/eslint-canary.svg?branch=master)](https://travis-ci.org/eslint/eslint-canary)
 
 Regression build for [ESLint](https://github.com/eslint/eslint)
 


### PR DESCRIPTION
96d15a304a06be4a6f9c411a6ea69a713991f3c4 updated the travis sticker to display the correct status, but it still links to the nonexistent repo.