### PR TITLE
Fix: make build pass with ESLint 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/not-an-aardvark/eslint-canary#readme",
   "devDependencies": {
-    "eslint": "^3.13.1",
+    "eslint": "^4.0.0-alpha.1",
     "eslint-config-eslint": "^3.0.0"
   },
   "dependencies": {

--- a/projects.yml
+++ b/projects.yml
@@ -12,6 +12,7 @@
   commit: c5a73d51483310f8443043d3927c2557993f3416
   args:
     - .
+    - --rule=indent:off
 
 - name: jquery
   repo: https://github.com/jquery/jquery
@@ -28,6 +29,8 @@
   args:
     - .
     - bin/*
+    - --rule=indent:off
+    - --rule=no-multi-spaces:[error, {ignoreEOLComments:true}]
 
 - name: node
   repo: https://github.com/nodejs/node
@@ -38,6 +41,8 @@
     - lib
     - test
     - tools
+    - --rule=indent:off
+    - --rule=no-multi-spaces:[error, {ignoreEOLComments:true}]
     - --rule=timer-arguments:off
 
 - name: redux
@@ -56,6 +61,8 @@
     - src
     - build
     - test
+    - --rule=indent:off
+    - --rule=no-multi-spaces:[error, {ignoreEOLComments:true}]
     - --rule=camelcase:off # There are several `camelcase` errors in the vue codebase for some reason
 
 - name: webpack
@@ -70,5 +77,7 @@
     - test/binCases/**/test.js
     - examples/**/webpack.config.js
     - --rule=node/no-missing-require:off # Prevent missing dependencies from erroring
+    - --rule=indent:off
+    - --rule=no-useless-escape:off
     - --rule=semi:off # There are several `semi` errors in the webpack codebase for some reason
     - --ignore-pattern=test/configCases/plugins/environment-plugin/webpack.config.js


### PR DESCRIPTION
The build has been failing for awhile due to some breaking changes in ESLint 4. This commit disables or reconfigures rules as appropriate to fix the errors.

We should eventually undo this change after projects update to ESLint 4 and fix their codebase/reconfigure their rules.