### PR TITLE
Update: webpack project to latest ESLint update

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -84,3 +84,5 @@
     - --rule=no-useless-escape:off
     - --rule=semi:off # There are several `semi` errors in the webpack codebase for some reason
     - --ignore-pattern=test/configCases/plugins/environment-plugin/webpack.config.js
+  dependencies:
+    - prettier

--- a/projects.yml
+++ b/projects.yml
@@ -83,6 +83,7 @@
     - --rule=indent:off
     - --rule=no-useless-escape:off
     - --rule=semi:off # There are several `semi` errors in the webpack codebase for some reason
+    - --rule=prettier/prettier:off # There are several errors with `prettier/prettier`, need to figure out what is missing in config
     - --ignore-pattern=test/configCases/plugins/environment-plugin/webpack.config.js
   dependencies:
     - prettier

--- a/projects.yml
+++ b/projects.yml
@@ -67,15 +67,18 @@
 
 - name: webpack
   repo: https://github.com/webpack/webpack
-  commit: bc840ec8747ba19c9e87629f2959ed2e65a9ffbe
+  commit: f1092ad516b77b763a5797e155b24ce0d37bd96b
   args:
+    - setup
     - lib
     - bin
     - hot
     - buildin
+    - test/*.js
     - test/**/webpack.config.js
     - test/binCases/**/test.js
     - examples/**/webpack.config.js
+    - schemas/**/*.js
     - --rule=node/no-missing-require:off # Prevent missing dependencies from erroring
     - --rule=indent:off
     - --rule=no-useless-escape:off


### PR DESCRIPTION
Had to add prettier to the install list, and then disable the prettier/prettier rule. :disappointed: Probably just missing a config change but I just want to get webpack passing for now (and I do intend to probe at the rule overrides in all the projects this week to see what overrides we could remove).

Travis results: [This pull request](https://travis-ci.org/eslint/eslint-canary/builds/374044104), vs [master](https://travis-ci.org/eslint/eslint-canary/builds/374027161)