### PR TITLE
Upgrade: eslint@^4.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/not-an-aardvark/eslint-canary#readme",
   "devDependencies": {
-    "eslint": "^4.0.0-alpha.1",
+    "eslint": "^4.19.1",
     "eslint-config-eslint": "^3.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Just making sure the Travis build is using latest stable ESLint.

For the nightly build, it might be a good idea to add a feature here to clone ESLint from GitHub as well, so that the nightly build is running latest code against the configured projects. I'll look into that later.