### PR TITLE
Fix: use npm^3 to install packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "homepage": "https://github.com/not-an-aardvark/eslint-canary#readme",
   "devDependencies": {
     "eslint": "^4.19.1",
-    "eslint-config-eslint": "^3.0.0"
+    "eslint-config-eslint": "^3.0.0",
+    "npm": "^3.10.10"
   },
   "dependencies": {
     "chai": "^3.5.0",

--- a/projects.yml
+++ b/projects.yml
@@ -44,6 +44,7 @@
     - --rule=indent:off
     - --rule=no-multi-spaces:[error, {ignoreEOLComments:true}]
     - --rule=timer-arguments:off
+    - --rule=no-self-assign:[error, {props:false}]
 
 - name: redux
   repo: https://github.com/reactjs/redux
@@ -51,7 +52,6 @@
   args:
     - src
     - test
-    - build
     - examples
 
 - name: vue
@@ -69,21 +69,16 @@
   repo: https://github.com/webpack/webpack
   commit: f1092ad516b77b763a5797e155b24ce0d37bd96b
   args:
-    - setup
     - lib
     - bin
     - hot
     - buildin
     - test/*.js
     - test/**/webpack.config.js
-    - test/binCases/**/test.js
     - examples/**/webpack.config.js
     - schemas/**/*.js
+    - --rule=no-self-assign:[error, {props:false}]
     - --rule=node/no-missing-require:off # Prevent missing dependencies from erroring
-    - --rule=indent:off
-    - --rule=no-useless-escape:off
-    - --rule=semi:off # There are several `semi` errors in the webpack codebase for some reason
     - --rule=prettier/prettier:off # There are several errors with `prettier/prettier`, need to figure out what is missing in config
-    - --ignore-pattern=test/configCases/plugins/environment-plugin/webpack.config.js
   dependencies:
     - prettier


### PR DESCRIPTION
This fixes the canary build on the Jenkins server by having it always use npm^3 internally when installing dependencies. (When running `npm test`, the local `npm` installation with the correct version will end up on the path.)

Eventually it would be a good idea to get this working with more recent npm versions, but this seems like a good first step in the meantime. The task should be significantly easier after we update configs to load plugins/shareable configs relative to themselves rather than ESLint.

ESLint team members can see the successful build [here](https://jenkins.eslint.org/job/Regression%20Builds/job/eslint-canary/631/console) (I temporarily updated the config to build from this branch).