### PR TITLE
Docs: Fix repo references in README and package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ eslint-canary path/to/package/folder/containing/eslint
 ## Development
 
 ```bash
-$ git clone https://github.com/not-an-aardvark/eslint-canary
+$ git clone https://github.com/eslint/eslint-canary
 $ cd eslint-canary
 $ npm install
 $ npm test

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/not-an-aardvark/eslint-canary.git"
+    "url": "git+https://github.com/eslint/eslint-canary.git"
   },
   "author": "Teddy Katz",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/not-an-aardvark/eslint-canary/issues"
+    "url": "https://github.com/eslint/eslint-canary/issues"
   },
-  "homepage": "https://github.com/not-an-aardvark/eslint-canary#readme",
+  "homepage": "https://github.com/eslint/eslint-canary#readme",
   "devDependencies": {
     "eslint": "^6.8.0",
     "eslint-config-eslint": "^6.0.0",


### PR DESCRIPTION
I'm aware that none of the links are actually broken and GitHub will happily redirect not-an-aardvark/eslint-canary.git to eslint/eslint-canary.git, but we might as well use the canonical URLs and avoid potential confusion.